### PR TITLE
feat: add catalog-linked image generation CLI (gpt-image-2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .env
 .DS_Store
 *.log
+output/

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -27,9 +27,12 @@ cp .env.example .env
 Edit `.env` and add your CMS credentials:
 
 ```env
-# Required for all scripts
+# Required for README generation / CMS-backed image generation
 CMS_HOST=https://your-cms-host.com
 CMS_API_KEY=your-api-key-here
+
+# Required for image generation (pnpm run image)
+OPENAI_API_KEY=sk-...
 ```
 
 ### 3. Test README Generation
@@ -88,6 +91,40 @@ npm run sync
 |--------|---------|-------------|
 | Generate README | `pnpm run generate` | Fetch prompts and generate README.md |
 | Sync Issue to CMS | `pnpm run sync` | Parse issue and sync to CMS (local testing) |
+| Generate Image | `pnpm run image ...` | Generate an image with `gpt-image-2` (see below) |
+| Run Tests | `pnpm test` | Run unit tests for the utility helpers |
+
+## 🎨 Image Generation
+
+Generate images from prompts with OpenAI `gpt-image-2`. Only `OPENAI_API_KEY`
+is required for the CMS-free paths (`--prompt`, `--no`); `--id`/`--list` also
+need `CMS_HOST`/`CMS_API_KEY`.
+
+```bash
+# Free text — no CMS needed
+pnpm run image --prompt "a cat astronaut, watercolor"
+
+# From a README prompt by its "No." — no CMS needed
+pnpm run image --no 5
+pnpm run image --readme-list           # discover available No. values
+
+# From a CMS prompt by id — needs CMS_HOST / CMS_API_KEY
+pnpm run image --id 42
+pnpm run image --list
+
+# Options
+#   --lang <locale>   use a localized README / CMS locale (default: en)
+#   --size <s>        default 1024x1024
+#   --quality <q>     low | medium | high | auto (default auto)
+#   --n <count>       number of images (default 1)
+#   --out <dir>       output directory (default output/)
+#   --format <fmt>    png | webp | jpeg (default png)
+#   --arg <text>      fill {argument...} placeholders in the prompt
+```
+
+Images are written to `output/` (git-ignored). Prompts flagged
+`needReferenceImages` (image-editing prompts) are not supported and are skipped
+with a warning.
 
 ## 🔧 How dotenv Works
 

--- a/docs/superpowers/plans/2026-07-16-catalog-image-generation-cli.md
+++ b/docs/superpowers/plans/2026-07-16-catalog-image-generation-cli.md
@@ -1,0 +1,615 @@
+# Catalog-Linked Image Generation CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a CLI that fetches a catalog prompt from the CMS by id and generates an image with OpenAI `gpt-image-2`, saving it locally.
+
+**Architecture:** A thin CLI (`scripts/generate-image.ts`) parses args, fetches the prompt via the existing `cms-client.ts` (new `fetchPromptById`), prepares the prompt text with pure helpers (`prompt-preparer.ts`), and calls an OpenAI wrapper (`image-generator.ts`) that returns decoded image buffers written under `output/`.
+
+**Tech Stack:** Node 20+, TypeScript run via `tsx` (no build/typecheck step), ESM, pnpm, `openai` SDK, Node built-ins `node:util` (parseArgs) and `node:test`.
+
+## Global Constraints
+
+- Node.js 20+; package manager pnpm (`packageManager: pnpm@9.15.9`).
+- ESM project (`"type": "module"`) — intra-repo imports use `.js` extensions even for `.ts` files (e.g. `./utils/cms-client.js`), matching existing code.
+- Scripts run via `tsx`; there is no `tsc` build or typecheck step in CI, so type-only friction does not block runtime.
+- Image model is hardcoded to `gpt-image-2`. Do not read the model from env.
+- Credentials come from `.env` (loaded with `import "dotenv/config"`): `OPENAI_API_KEY`, `CMS_HOST`, `CMS_API_KEY`.
+- Never print the API key in logs or errors.
+- No source files in the repo root — new code lives under `scripts/`. Generated images go under `output/` (git-ignored).
+- CMS auth header format (existing): `Authorization: users API-Key ${CMS_API_KEY}`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `scripts/utils/prompt-preparer.ts` (create) | Pure functions: clean prompt content, detect/substitute `{argument}` placeholders, slugify, build output filename. |
+| `scripts/utils/prompt-preparer.test.ts` (create) | `node:test` unit tests for the pure functions. |
+| `scripts/utils/cms-client.ts` (modify) | Add `fetchPromptById(id, locale)`. |
+| `scripts/utils/image-generator.ts` (create) | Wrapper over `openai.images.generate` → `Buffer[]`. |
+| `scripts/generate-image.ts` (create) | CLI entry point wiring the above. |
+| `package.json` (modify) | Add `image` + `test` scripts and `openai` dependency. |
+| `.gitignore` (modify) | Add `output/`. |
+
+---
+
+### Task 1: Pure prompt-preparation helpers (TDD)
+
+**Files:**
+- Create: `scripts/utils/prompt-preparer.ts`
+- Test: `scripts/utils/prompt-preparer.test.ts`
+- Modify: `package.json` (add `test` script)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `cleanPromptContent(content: string): string`
+  - `hasArguments(content: string): boolean`
+  - `substituteArguments(content: string, value: string): string`
+  - `slugify(title: string, maxLen?: number): string`
+  - `buildImageFilename(id: number, title: string, index: number, format: string): string`
+
+- [ ] **Step 1: Add the `test` script to `package.json`**
+
+In `package.json`, add a `test` entry to `scripts` (keep existing `generate` and `sync`):
+
+```json
+  "scripts": {
+    "generate": "tsx scripts/generate-readme.ts",
+    "sync": "tsx scripts/sync-approved-to-cms.ts",
+    "test": "tsx --test scripts/utils/*.test.ts"
+  },
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `scripts/utils/prompt-preparer.test.ts`:
+
+```ts
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  cleanPromptContent,
+  hasArguments,
+  substituteArguments,
+  slugify,
+  buildImageFilename,
+} from "./prompt-preparer.js";
+
+test("cleanPromptContent strips a plain ``` fence and trims", () => {
+  const input = "```\nA red cube on white\n```";
+  assert.equal(cleanPromptContent(input), "A red cube on white");
+});
+
+test("cleanPromptContent strips a ```json language fence", () => {
+  const input = "```json\n{\"a\":1}\n```";
+  assert.equal(cleanPromptContent(input), '{"a":1}');
+});
+
+test("cleanPromptContent returns plain text unchanged (trimmed)", () => {
+  assert.equal(cleanPromptContent("  hello  "), "hello");
+});
+
+test("hasArguments detects {argument tokens", () => {
+  assert.equal(hasArguments("draw {argument name=\"x\"}"), true);
+  assert.equal(hasArguments("draw a cat"), false);
+});
+
+test("substituteArguments replaces every {argument...} token", () => {
+  const out = substituteArguments("A {argument} riding a {argument name=\"y\"}", "dog");
+  assert.equal(out, "A dog riding a dog");
+});
+
+test("slugify lowercases, hyphenates, and truncates", () => {
+  assert.equal(slugify("A Red Cube!! On White"), "a-red-cube-on-white");
+  assert.equal(slugify("x".repeat(60), 10), "xxxxxxxxxx");
+});
+
+test("slugify falls back to 'prompt' for non-latin titles", () => {
+  assert.equal(slugify("猫の宇宙飛行士"), "prompt");
+});
+
+test("buildImageFilename composes id, slug, 1-based index, and format", () => {
+  assert.equal(buildImageFilename(42, "Cat Astronaut", 0, "png"), "42-cat-astronaut-1.png");
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `pnpm test`
+Expected: FAIL — cannot find module `./prompt-preparer.js` (file not created yet).
+
+- [ ] **Step 4: Write the implementation**
+
+Create `scripts/utils/prompt-preparer.ts`:
+
+```ts
+/**
+ * Remove code-block markers (``` or ```json etc.) from prompt content.
+ * Mirrors the logic in markdown-generator.ts; kept separate so the README
+ * pipeline stays untouched in v1.
+ */
+export function cleanPromptContent(content: string): string {
+  if (!content) return content;
+  let cleaned = content;
+  cleaned = cleaned.replace(/^```[\w-]*\s*\n?/im, "");
+  cleaned = cleaned.replace(/\n?```\s*$/im, "");
+  cleaned = cleaned.replace(/\n```[\w-]*\s*\n/g, "\n");
+  return cleaned.trim();
+}
+
+/** True when the prompt still contains Raycast-style {argument...} placeholders. */
+export function hasArguments(content: string): boolean {
+  return content.includes("{argument");
+}
+
+/** Replace every {argument...} token with the provided value. */
+export function substituteArguments(content: string, value: string): string {
+  return content.replace(/\{argument[^}]*\}/g, value);
+}
+
+/** Filesystem-safe slug from a title. Falls back to "prompt" when empty. */
+export function slugify(title: string, maxLen = 40): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug.slice(0, maxLen).replace(/-+$/g, "") || "prompt";
+}
+
+/** Build an output filename like `42-cat-astronaut-1.png` (index is 0-based). */
+export function buildImageFilename(
+  id: number,
+  title: string,
+  index: number,
+  format: string
+): string {
+  return `${id}-${slugify(title)}-${index + 1}.${format}`;
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm test`
+Expected: PASS — all 8 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/utils/prompt-preparer.ts scripts/utils/prompt-preparer.test.ts package.json
+git commit -m "feat: add pure prompt-preparation helpers with tests"
+```
+
+---
+
+### Task 2: `fetchPromptById` in cms-client
+
+**Files:**
+- Modify: `scripts/utils/cms-client.ts`
+
+**Interfaces:**
+- Consumes: existing `Prompt` interface, `processPromptImages` (private, same file), `CMS_HOST`, `CMS_API_KEY`.
+- Produces: `fetchPromptById(id: number | string, locale?: string): Promise<Prompt | null>` — returns the prompt with `sourceMedia` populated, or `null` on 404.
+
+- [ ] **Step 1: Add the function**
+
+In `scripts/utils/cms-client.ts`, add after `findPromptByGitHubIssue` (it relies on `processPromptImages`, `CMS_HOST`, `CMS_API_KEY`, `fetch`, and `stringify`, all already in this file):
+
+```ts
+/**
+ * Fetch a single prompt by its CMS id.
+ * Returns null when the prompt does not exist (HTTP 404).
+ */
+export async function fetchPromptById(
+  id: number | string,
+  locale: string = "en"
+): Promise<Prompt | null> {
+  const query = { depth: 2, locale };
+  const stringifiedQuery = stringify(query, { addQueryPrefix: true });
+  const url = `${CMS_HOST}/api/prompts/${id}${stringifiedQuery}`;
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `users API-Key ${CMS_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(
+      `CMS API error (${response.status}) fetching prompt ${id}: ${response.statusText}`
+    );
+  }
+
+  const data = (await response.json()) as Prompt;
+  return processPromptImages(data);
+}
+```
+
+- [ ] **Step 2: Typecheck-free sanity run**
+
+Run: `pnpm exec tsx -e "import('./scripts/utils/cms-client.ts').then(m => console.log(typeof m.fetchPromptById))"`
+Expected: prints `function` (module loads, export exists). No network call is made.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/utils/cms-client.ts
+git commit -m "feat: add fetchPromptById to cms-client"
+```
+
+---
+
+### Task 3: OpenAI image-generator wrapper
+
+**Files:**
+- Create: `scripts/utils/image-generator.ts`
+- Modify: `package.json` (add `openai` dependency via install)
+
+**Interfaces:**
+- Consumes: `process.env.OPENAI_API_KEY`, the `openai` SDK.
+- Produces:
+  - types `ImageQuality = "low" | "medium" | "high" | "auto"`, `ImageFormat = "png" | "webp" | "jpeg"`, `GenerateOptions`
+  - `generateImages(prompt: string, opts?: GenerateOptions): Promise<Buffer[]>`
+
+- [ ] **Step 1: Install the OpenAI SDK**
+
+Run: `pnpm add openai`
+Expected: `openai` added to `dependencies` in `package.json` and `pnpm-lock.yaml` updated.
+
+- [ ] **Step 2: Write the wrapper**
+
+Create `scripts/utils/image-generator.ts`:
+
+```ts
+import OpenAI from "openai";
+
+export type ImageQuality = "low" | "medium" | "high" | "auto";
+export type ImageFormat = "png" | "webp" | "jpeg";
+
+export interface GenerateOptions {
+  size?: string;
+  quality?: ImageQuality;
+  n?: number;
+  format?: ImageFormat;
+}
+
+const MODEL = "gpt-image-2";
+
+/**
+ * Generate images from a text prompt with gpt-image-2.
+ * gpt-image models always return base64, so each image is decoded to a Buffer.
+ */
+export async function generateImages(
+  prompt: string,
+  opts: GenerateOptions = {}
+): Promise<Buffer[]> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is not set");
+  }
+
+  const client = new OpenAI({ apiKey });
+
+  // tsx strips types at runtime, so passing gpt-image-2 params the installed
+  // SDK types may not know about (e.g. output_format) is safe.
+  const result = await client.images.generate({
+    model: MODEL,
+    prompt,
+    size: opts.size ?? "1024x1024",
+    quality: opts.quality ?? "auto",
+    n: opts.n ?? 1,
+    output_format: opts.format ?? "png",
+  } as OpenAI.ImageGenerateParams);
+
+  const data = result.data ?? [];
+  if (data.length === 0) {
+    throw new Error("Image API returned no images");
+  }
+
+  return data.map((img) => {
+    if (!img.b64_json) {
+      throw new Error("Image API response missing b64_json");
+    }
+    return Buffer.from(img.b64_json, "base64");
+  });
+}
+```
+
+- [ ] **Step 3: Module-load sanity run**
+
+Run: `pnpm exec tsx -e "import('./scripts/utils/image-generator.ts').then(m => console.log(typeof m.generateImages))"`
+Expected: prints `function`. No API call is made.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/utils/image-generator.ts package.json pnpm-lock.yaml
+git commit -m "feat: add openai image-generator wrapper"
+```
+
+---
+
+### Task 4: CLI entry point + gitignore
+
+**Files:**
+- Create: `scripts/generate-image.ts`
+- Modify: `package.json` (add `image` script)
+- Modify: `.gitignore` (add `output/`)
+
+**Interfaces:**
+- Consumes: `fetchPromptById`, `fetchAllPrompts`, `fetchPromptCategories` (cms-client); `generateImages`, `ImageQuality`, `ImageFormat` (image-generator); `cleanPromptContent`, `hasArguments`, `substituteArguments`, `buildImageFilename` (prompt-preparer).
+- Produces: the `pnpm run image` command.
+
+- [ ] **Step 1: Ignore the output directory**
+
+In `.gitignore`, add a line:
+
+```
+output/
+```
+
+- [ ] **Step 2: Add the `image` script to `package.json`**
+
+In `package.json` `scripts`, add:
+
+```json
+    "image": "tsx scripts/generate-image.ts",
+```
+
+Resulting `scripts` block:
+
+```json
+  "scripts": {
+    "generate": "tsx scripts/generate-readme.ts",
+    "sync": "tsx scripts/sync-approved-to-cms.ts",
+    "image": "tsx scripts/generate-image.ts",
+    "test": "tsx --test scripts/utils/*.test.ts"
+  },
+```
+
+- [ ] **Step 3: Write the CLI**
+
+Create `scripts/generate-image.ts`:
+
+```ts
+import "dotenv/config";
+import fs from "fs";
+import path from "path";
+import { parseArgs } from "node:util";
+import {
+  fetchPromptById,
+  fetchAllPrompts,
+  fetchPromptCategories,
+} from "./utils/cms-client.js";
+import {
+  generateImages,
+  type ImageQuality,
+  type ImageFormat,
+} from "./utils/image-generator.js";
+import {
+  cleanPromptContent,
+  hasArguments,
+  substituteArguments,
+  buildImageFilename,
+} from "./utils/prompt-preparer.js";
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`❌ Environment variable ${name} is not set. Add it to .env`);
+    process.exit(1);
+  }
+  return v;
+}
+
+async function runList(lang: string, limit: number): Promise<void> {
+  requireEnv("CMS_HOST");
+  requireEnv("CMS_API_KEY");
+
+  const { allCategories } = await fetchPromptCategories(lang);
+  const { docs } = await fetchAllPrompts(lang, allCategories);
+
+  console.log(`\nAvailable prompts (${Math.min(limit, docs.length)} of ${docs.length}):\n`);
+  docs.slice(0, limit).forEach((p) => {
+    const marks = `${p.featured ? "⭐" : ""}${p.needReferenceImages ? "🖼️" : ""}`;
+    console.log(`  ${String(p.id).padStart(5)}  ${marks ? marks + " " : ""}${p.title}`);
+  });
+  console.log("\nUse: pnpm run image --id <id>\n");
+}
+
+interface GenerateParams {
+  id: string;
+  lang: string;
+  size: string;
+  quality: ImageQuality;
+  n: number;
+  out: string;
+  format: ImageFormat;
+  arg?: string;
+}
+
+async function runGenerate(params: GenerateParams): Promise<void> {
+  requireEnv("OPENAI_API_KEY");
+  requireEnv("CMS_HOST");
+  requireEnv("CMS_API_KEY");
+
+  console.log(`📥 Fetching prompt id=${params.id} from CMS...`);
+  const prompt = await fetchPromptById(params.id, params.lang);
+  if (!prompt) {
+    console.error(`❌ prompt id=${params.id} not found`);
+    process.exit(1);
+  }
+
+  if (prompt.needReferenceImages) {
+    console.error(
+      `⚠️  id=${params.id} ("${prompt.title}") requires an input image, which v1 does not support. Use --image once editing is added. Skipping.`
+    );
+    process.exit(1);
+  }
+
+  const rawText =
+    params.lang !== "en" && prompt.translatedContent
+      ? prompt.translatedContent
+      : prompt.content;
+  let promptText = cleanPromptContent(rawText);
+
+  if (hasArguments(promptText)) {
+    if (params.arg) {
+      promptText = substituteArguments(promptText, params.arg);
+      console.log(`🔤 Substituted {argument} placeholders with: "${params.arg}"`);
+    } else {
+      console.warn(
+        `⚠️  Prompt contains unresolved {argument} placeholders. Pass --arg "<text>" to fill them. Continuing as-is.`
+      );
+    }
+  }
+
+  console.log(
+    `🎨 Generating ${params.n} image(s) with gpt-image-2 (size=${params.size}, quality=${params.quality})...`
+  );
+  const buffers = await generateImages(promptText, {
+    size: params.size,
+    quality: params.quality,
+    n: params.n,
+    format: params.format,
+  });
+
+  fs.mkdirSync(params.out, { recursive: true });
+  buffers.forEach((buf, i) => {
+    const filename = buildImageFilename(prompt.id, prompt.title, i, params.format);
+    const filepath = path.join(params.out, filename);
+    fs.writeFileSync(filepath, buf);
+    console.log(`✅ Saved ${filepath}`);
+  });
+}
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: {
+      id: { type: "string" },
+      list: { type: "boolean", default: false },
+      limit: { type: "string", default: "50" },
+      lang: { type: "string", default: "en" },
+      size: { type: "string", default: "1024x1024" },
+      quality: { type: "string", default: "auto" },
+      n: { type: "string", default: "1" },
+      out: { type: "string", default: "output" },
+      format: { type: "string", default: "png" },
+      arg: { type: "string" },
+    },
+  });
+
+  if (values.list) {
+    await runList(values.lang as string, parseInt(values.limit as string, 10));
+    return;
+  }
+
+  if (!values.id) {
+    console.error(
+      "Usage:\n" +
+        "  pnpm run image --id <id> [--lang <locale>] [--size <s>] [--quality <q>] [--n <count>] [--out <dir>] [--format <fmt>] [--arg <text>]\n" +
+        "  pnpm run image --list [--limit <n>]"
+    );
+    process.exit(1);
+  }
+
+  await runGenerate({
+    id: values.id as string,
+    lang: values.lang as string,
+    size: values.size as string,
+    quality: values.quality as ImageQuality,
+    n: parseInt(values.n as string, 10),
+    out: values.out as string,
+    format: values.format as ImageFormat,
+    arg: values.arg as string | undefined,
+  });
+}
+
+main().catch((err) => {
+  console.error("❌", err?.message ?? err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 4: Verify the usage/help path (no network)**
+
+Run: `pnpm run image`
+Expected: prints the `Usage:` block and exits non-zero (no `--id` / `--list`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/generate-image.ts package.json .gitignore
+git commit -m "feat: add catalog-linked image generation CLI"
+```
+
+---
+
+### Task 5: End-to-end verification (manual, requires live credentials)
+
+**Files:** none (verification only).
+
+This task exercises the real CMS and OpenAI API using the keys in `.env`. It is the acceptance check for the feature.
+
+- [ ] **Step 1: Install dependencies**
+
+Run: `pnpm install`
+Expected: completes without error; `openai` present in `node_modules`.
+
+- [ ] **Step 2: Unit tests pass**
+
+Run: `pnpm test`
+Expected: all prompt-preparer tests PASS.
+
+- [ ] **Step 3: List prompts from the CMS**
+
+Run: `pnpm run image --list --limit 10`
+Expected: a table of up to 10 prompts with numeric ids and titles. Note a text-to-image id (no `🖼️`) and a `🖼️` id for later.
+
+- [ ] **Step 4: Generate from a text-to-image prompt**
+
+Run: `pnpm run image --id <text-to-image-id>`
+Expected: logs "Generating 1 image(s)...", then "✅ Saved output/<id>-<slug>-1.png". Open the PNG and confirm it is a valid image.
+
+- [ ] **Step 5: Reference-image prompt is refused**
+
+Run: `pnpm run image --id <needReferenceImages-id>`
+Expected: prints the "requires an input image" warning and exits non-zero; no file written.
+
+- [ ] **Step 6: Update LOCAL_DEVELOPMENT docs**
+
+In `docs/LOCAL_DEVELOPMENT.md`, add `OPENAI_API_KEY` to the env section and add an "Image Generation" row to the scripts table documenting `pnpm run image --id <id>` and `pnpm run image --list`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/LOCAL_DEVELOPMENT.md
+git commit -m "docs: document image generation CLI in local development guide"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- CLI `--id` generation → Task 4. ✅
+- `--list` discovery → Task 4 (`runList`). ✅
+- Text-to-image via `images.generate`, model `gpt-image-2` → Task 3. ✅
+- Env from `.env` (`OPENAI_API_KEY`/`CMS_HOST`/`CMS_API_KEY`) → Task 4 (`requireEnv`), Task 3 (key check). ✅
+- Save under `output/`, git-ignored → Task 4 (Steps 1, 3). ✅
+- Live CMS fetch by id (`fetchPromptById`) → Task 2. ✅
+- `needReferenceImages` warn + abort → Task 4 (`runGenerate`). ✅
+- Prompt-text choice (content vs translatedContent), clean fences, `{argument}` handling → Task 4 + Task 1. ✅
+- Error handling (missing env, CMS non-2xx / 404, OpenAI errors, unresolved args) → Tasks 2, 3, 4. ✅
+- Tests via `node:test`/`tsx`, `test` script → Task 1. ✅
+- Verification flow → Task 5. ✅
+
+**Placeholder scan:** No TBD/TODO; every code step contains full code. ✅
+
+**Type consistency:** `generateImages(prompt, opts)`, `GenerateOptions { size, quality, n, format }`, `ImageQuality`/`ImageFormat`, `fetchPromptById(id, locale)`, and the prompt-preparer signatures are used identically across tasks. ✅

--- a/docs/superpowers/specs/2026-07-16-catalog-image-generation-cli-design.md
+++ b/docs/superpowers/specs/2026-07-16-catalog-image-generation-cli-design.md
@@ -145,6 +145,24 @@ The repo currently has no test runner. Use Node's built-in `node:test` run via
 4. `pnpm run image --id <id>` on a text-to-image prompt — writes a PNG to `output/`.
 5. `pnpm run image --id <id>` on a `needReferenceImages` prompt — warns and exits.
 
+## Amendment (2026-07-16): CMS-optional paths
+
+During end-to-end verification, `.env` was found to contain only a real
+`OPENAI_API_KEY`; `CMS_HOST`/`CMS_API_KEY` were still the `.env.example`
+placeholders, so the CMS-backed `--id`/`--list` paths could not reach a CMS.
+Per user decision, two CMS-free paths were added so the tool is usable with just
+`OPENAI_API_KEY`, while the CMS paths remain for when real credentials are set:
+
+- `--prompt "<text>"` — generate from arbitrary free text (no CMS, no README).
+- `--no <number>` — generate from a prompt parsed out of the local README by its
+  "No." heading (no CMS). Added `scripts/utils/readme-parser.ts`
+  (`parseReadmePrompts`, `getReadmePromptByNo`) with unit tests.
+- `--readme-list` — list prompts parsed from the README.
+
+Routing precedence in the CLI: `--prompt` → `--no` → `--readme-list` →
+`--list` → `--id` → usage. The `gpt-image-2` model, output handling, and
+`needReferenceImages` behavior are unchanged.
+
 ## Open questions
 
 None. All brainstorming decisions resolved.

--- a/docs/superpowers/specs/2026-07-16-catalog-image-generation-cli-design.md
+++ b/docs/superpowers/specs/2026-07-16-catalog-image-generation-cli-design.md
@@ -1,0 +1,150 @@
+# Catalog-Linked Image Generation CLI — Design
+
+**Date:** 2026-07-16
+**Status:** Approved (pending spec review)
+
+## Purpose
+
+This repository is a curated catalog of GPT Image 2 prompts. Prompts live in a
+Payload CMS and are rendered into multilingual README files. Today there is no
+way to actually generate an image from a catalog prompt.
+
+This feature adds a CLI that takes a catalog prompt (by CMS id), sends its
+prompt text to OpenAI's `gpt-image-2` model, and saves the resulting image
+locally.
+
+## Scope
+
+### In scope (v1)
+- `pnpm run image --id <id>` — fetch a prompt from the CMS by id and generate an image.
+- `pnpm run image --list` — list available prompts (id + title) to discover ids.
+- Text-to-image generation only, via `openai.images.generate`.
+- Model fixed to `gpt-image-2`.
+- Uses `OPENAI_API_KEY`, `CMS_HOST`, `CMS_API_KEY` from `.env`.
+- Save images under `output/` (git-ignored).
+
+### Out of scope (YAGNI for v1)
+- Image editing / reference-image input (`openai.images.edit`).
+- Web UI.
+- Integration into the README generation pipeline.
+- Batch generation of the entire catalog.
+
+## Decisions (from brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Delivery form | Catalog-linked CLI |
+| Prompt source | Live fetch from CMS (reuse `cms-client.ts`) |
+| Model | `gpt-image-2` (hardcoded) |
+| Credentials | `OPENAI_API_KEY` from `.env` |
+| `needReferenceImages: true` prompts | Warn and abort (v1 does not support reference images) |
+
+## Architecture
+
+### New files
+
+| File | Responsibility |
+|---|---|
+| `scripts/generate-image.ts` | CLI entry point: parse args → fetch prompt → generate → save. |
+| `scripts/utils/image-generator.ts` | Thin wrapper over `openai.images.generate`. Input: prompt text + options. Output: array of image buffers. |
+| `scripts/utils/prompt-preparer.ts` | Pure functions: clean prompt content, detect/substitute `{argument}` placeholders, build output filename slug. Unit-tested. |
+| `scripts/utils/prompt-preparer.test.ts` | `node:test` unit tests for the pure functions. |
+
+### Changed files
+
+| File | Change |
+|---|---|
+| `scripts/utils/cms-client.ts` | Add `fetchPromptById(id, locale)` using `GET /api/prompts/:id`. |
+| `package.json` | Add script `"image"`, script `"test"`, and dependency `openai`. |
+| `.gitignore` | Add `output/`. |
+
+### Module boundaries
+
+- `prompt-preparer.ts` is pure (no network, no fs) so it is independently testable.
+- `image-generator.ts` isolates the OpenAI SDK so the CLI does not depend on SDK
+  shape directly and the SDK can be mocked in tests.
+- `cms-client.ts` remains the single place that knows the CMS REST shape.
+
+## CLI interface
+
+```
+pnpm run image --id <id> [options]
+pnpm run image --list [--limit 50]
+
+options:
+  --id <number>     CMS prompt id (the number in README "?id=" links)
+  --list            List available prompts (id, title, markers) and exit
+  --limit <n>       Max rows for --list (default 50)
+  --lang <locale>   Use translatedContent for this locale (default: original `content`)
+  --size <size>     Image size (default 1024x1024)
+  --quality <q>     low | medium | high | auto (default auto)
+  --n <count>       Number of images to generate (default 1)
+  --out <dir>       Output directory (default output/)
+  --format <fmt>    png | webp | jpeg (default png)
+  --arg <text>      Text to substitute into {argument...} placeholders
+```
+
+## Generation flow (`--id`)
+
+1. Load `.env` via `dotenv/config`. Validate `OPENAI_API_KEY`, `CMS_HOST`,
+   `CMS_API_KEY`. On any missing key, print a clear error and exit non-zero.
+2. `fetchPromptById(id, lang)` from the CMS. On 404 / not found, print
+   "prompt id=<id> not found" and exit non-zero.
+3. If `needReferenceImages === true`: print a warning that the prompt requires
+   an input image (unsupported in v1) and exit non-zero.
+4. Prepare the prompt text:
+   - Choose `translatedContent` if `--lang` is given and present, else `content`.
+   - Strip code-block markers. `prompt-preparer.ts` gets its own
+     `cleanPromptContent` (logic mirrored from `markdown-generator.ts`). The
+     existing README pipeline is left untouched in v1 to avoid regressions; a
+     later cleanup can DRY the two.
+   - If `{argument...}` placeholders remain:
+     - If `--arg <text>` is provided, replace all `{argument...}` tokens with it.
+     - Otherwise print a warning that placeholders are unresolved and continue.
+5. Call `image-generator.generate(promptText, { size, quality, n, format })` with
+   model hardcoded to `gpt-image-2`. The result is base64 (`data[i].b64_json`),
+   decoded to Buffers.
+6. Write each image to `output/<id>-<title-slug>-<index>.<format>` and print the
+   saved path(s).
+
+## Generation flow (`--list`)
+
+1. Validate `CMS_HOST` / `CMS_API_KEY`.
+2. Reuse `fetchAllPrompts(lang, categories)` to gather prompts.
+3. Print a table of `id`, `title`, and markers (`⭐` featured,
+   `🖼️` needReferenceImages) up to `--limit`.
+
+## Error handling
+
+- Missing env var → explicit message naming the variable; exit 1.
+- CMS non-2xx → surface status + which id/endpoint failed.
+- OpenAI errors (model unavailable, moderation block, rate limit) → catch, print
+  the API message, exit 1. Do not print the API key.
+- Unresolved `{argument}` placeholders → warning, not fatal (image still attempted).
+
+## Testing
+
+The repo currently has no test runner. Use Node's built-in `node:test` run via
+`tsx` — no new test-framework dependency.
+
+- `package.json`: `"test": "tsx --test scripts/**/*.test.ts"`.
+- `prompt-preparer.test.ts` covers:
+  - `cleanPromptContent`: strips ` ``` ` / ` ```json ` fences, trims.
+  - argument detection: true when `{argument` present, false otherwise.
+  - argument substitution: `--arg` text replaces all `{argument...}` tokens.
+  - slug builder: title → filesystem-safe slug (lowercase, hyphenated, truncated).
+- Network layers (`cms-client`, `image-generator`) are not unit-tested in v1;
+  they are exercised by a manual end-to-end run (`pnpm run image --list`, then
+  `pnpm run image --id <id>`) documented in the plan.
+
+## Verification (manual, end-to-end)
+
+1. `pnpm install` (adds `openai`).
+2. `pnpm test` — pure-function tests pass.
+3. `pnpm run image --list` — prints prompts from the CMS.
+4. `pnpm run image --id <id>` on a text-to-image prompt — writes a PNG to `output/`.
+5. `pnpm run image --id <id>` on a `needReferenceImages` prompt — warns and exits.
+
+## Open questions
+
+None. All brainstorming decisions resolved.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "generate": "tsx scripts/generate-readme.ts",
     "sync": "tsx scripts/sync-approved-to-cms.ts",
+    "image": "tsx scripts/generate-image.ts",
     "test": "tsx --test scripts/utils/*.test.ts"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "generate": "tsx scripts/generate-readme.ts",
-    "sync": "tsx scripts/sync-approved-to-cms.ts"
+    "sync": "tsx scripts/sync-approved-to-cms.ts",
+    "test": "tsx --test scripts/utils/*.test.ts"
   },
   "devDependencies": {
     "@octokit/rest": "^20.0.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "node-fetch": "^3.3.2",
+    "openai": "^6.47.0",
     "qs-esm": "^7.0.2"
   },
   "packageManager": "pnpm@9.15.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
+      openai:
+        specifier: ^6.47.0
+        version: 6.47.0
       qs-esm:
         specifier: ^7.0.2
         version: 7.0.3
@@ -291,6 +294,26 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  openai@6.47.0:
+    resolution: {integrity: sha512-xYr+R9woSzWxVxeiqkkNbHhv89tZDEI6eBMbrdPnv3poh+mijHvbhS35a+3o6xHa411/ns8j5ENY3So9DCXWYw==}
+    peerDependencies:
+      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
+      '@smithy/hash-node': '>=4.3.0 <5'
+      '@smithy/signature-v4': '>=5.4.0 <6'
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@smithy/hash-node':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   qs-esm@7.0.3:
     resolution: {integrity: sha512-8jbjCR0PPbqoQcv83C2K/zvVeytRPwPpt3WPDbq51qyLAxcWGtXVRjSe6GHtLCoVbg9+NEFkv7GyUxqjcDIJzw==}
     engines: {node: '>=18'}
@@ -532,6 +555,8 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  openai@6.47.0: {}
 
   qs-esm@7.0.3: {}
 

--- a/scripts/generate-image.ts
+++ b/scripts/generate-image.ts
@@ -1,0 +1,157 @@
+import "dotenv/config";
+import fs from "fs";
+import path from "path";
+import { parseArgs } from "node:util";
+import {
+  fetchPromptById,
+  fetchAllPrompts,
+  fetchPromptCategories,
+} from "./utils/cms-client.js";
+import {
+  generateImages,
+  type ImageQuality,
+  type ImageFormat,
+} from "./utils/image-generator.js";
+import {
+  cleanPromptContent,
+  hasArguments,
+  substituteArguments,
+  buildImageFilename,
+} from "./utils/prompt-preparer.js";
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`❌ Environment variable ${name} is not set. Add it to .env`);
+    process.exit(1);
+  }
+  return v;
+}
+
+async function runList(lang: string, limit: number): Promise<void> {
+  requireEnv("CMS_HOST");
+  requireEnv("CMS_API_KEY");
+
+  const { allCategories } = await fetchPromptCategories(lang);
+  const { docs } = await fetchAllPrompts(lang, allCategories);
+
+  console.log(`\nAvailable prompts (${Math.min(limit, docs.length)} of ${docs.length}):\n`);
+  docs.slice(0, limit).forEach((p) => {
+    const marks = `${p.featured ? "⭐" : ""}${p.needReferenceImages ? "🖼️" : ""}`;
+    console.log(`  ${String(p.id).padStart(5)}  ${marks ? marks + " " : ""}${p.title}`);
+  });
+  console.log("\nUse: pnpm run image --id <id>\n");
+}
+
+interface GenerateParams {
+  id: string;
+  lang: string;
+  size: string;
+  quality: ImageQuality;
+  n: number;
+  out: string;
+  format: ImageFormat;
+  arg?: string;
+}
+
+async function runGenerate(params: GenerateParams): Promise<void> {
+  requireEnv("OPENAI_API_KEY");
+  requireEnv("CMS_HOST");
+  requireEnv("CMS_API_KEY");
+
+  console.log(`📥 Fetching prompt id=${params.id} from CMS...`);
+  const prompt = await fetchPromptById(params.id, params.lang);
+  if (!prompt) {
+    console.error(`❌ prompt id=${params.id} not found`);
+    process.exit(1);
+  }
+
+  if (prompt.needReferenceImages) {
+    console.error(
+      `⚠️  id=${params.id} ("${prompt.title}") requires an input image, which v1 does not support. Use --image once editing is added. Skipping.`
+    );
+    process.exit(1);
+  }
+
+  const rawText =
+    params.lang !== "en" && prompt.translatedContent
+      ? prompt.translatedContent
+      : prompt.content;
+  let promptText = cleanPromptContent(rawText);
+
+  if (hasArguments(promptText)) {
+    if (params.arg) {
+      promptText = substituteArguments(promptText, params.arg);
+      console.log(`🔤 Substituted {argument} placeholders with: "${params.arg}"`);
+    } else {
+      console.warn(
+        `⚠️  Prompt contains unresolved {argument} placeholders. Pass --arg "<text>" to fill them. Continuing as-is.`
+      );
+    }
+  }
+
+  console.log(
+    `🎨 Generating ${params.n} image(s) with gpt-image-2 (size=${params.size}, quality=${params.quality})...`
+  );
+  const buffers = await generateImages(promptText, {
+    size: params.size,
+    quality: params.quality,
+    n: params.n,
+    format: params.format,
+  });
+
+  fs.mkdirSync(params.out, { recursive: true });
+  buffers.forEach((buf, i) => {
+    const filename = buildImageFilename(prompt.id, prompt.title, i, params.format);
+    const filepath = path.join(params.out, filename);
+    fs.writeFileSync(filepath, buf);
+    console.log(`✅ Saved ${filepath}`);
+  });
+}
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: {
+      id: { type: "string" },
+      list: { type: "boolean", default: false },
+      limit: { type: "string", default: "50" },
+      lang: { type: "string", default: "en" },
+      size: { type: "string", default: "1024x1024" },
+      quality: { type: "string", default: "auto" },
+      n: { type: "string", default: "1" },
+      out: { type: "string", default: "output" },
+      format: { type: "string", default: "png" },
+      arg: { type: "string" },
+    },
+  });
+
+  if (values.list) {
+    await runList(values.lang as string, parseInt(values.limit as string, 10));
+    return;
+  }
+
+  if (!values.id) {
+    console.error(
+      "Usage:\n" +
+        "  pnpm run image --id <id> [--lang <locale>] [--size <s>] [--quality <q>] [--n <count>] [--out <dir>] [--format <fmt>] [--arg <text>]\n" +
+        "  pnpm run image --list [--limit <n>]"
+    );
+    process.exit(1);
+  }
+
+  await runGenerate({
+    id: values.id as string,
+    lang: values.lang as string,
+    size: values.size as string,
+    quality: values.quality as ImageQuality,
+    n: parseInt(values.n as string, 10),
+    out: values.out as string,
+    format: values.format as ImageFormat,
+    arg: values.arg as string | undefined,
+  });
+}
+
+main().catch((err) => {
+  console.error("❌", err?.message ?? err);
+  process.exit(1);
+});

--- a/scripts/generate-image.ts
+++ b/scripts/generate-image.ts
@@ -7,6 +7,7 @@ import {
   fetchAllPrompts,
   fetchPromptCategories,
 } from "./utils/cms-client.js";
+import { SUPPORTED_LANGUAGES } from "./utils/markdown-generator.js";
 import {
   generateImages,
   type ImageQuality,
@@ -16,8 +17,19 @@ import {
   cleanPromptContent,
   hasArguments,
   substituteArguments,
+  slugify,
   buildImageFilename,
 } from "./utils/prompt-preparer.js";
+import { getReadmePromptByNo, parseReadmePrompts } from "./utils/readme-parser.js";
+
+interface OutputOptions {
+  size: string;
+  quality: ImageQuality;
+  n: number;
+  out: string;
+  format: ImageFormat;
+  arg?: string;
+}
 
 function requireEnv(name: string): string {
   const v = process.env[name];
@@ -27,6 +39,50 @@ function requireEnv(name: string): string {
   }
   return v;
 }
+
+/** Substitute or warn about {argument} placeholders. */
+function applyArgs(promptText: string, arg?: string): string {
+  if (!hasArguments(promptText)) return promptText;
+  if (arg) {
+    console.log(`🔤 Substituted {argument} placeholders with: "${arg}"`);
+    return substituteArguments(promptText, arg);
+  }
+  console.warn(
+    `⚠️  Prompt contains unresolved {argument} placeholders. Pass --arg "<text>" to fill them. Continuing as-is.`
+  );
+  return promptText;
+}
+
+/** Generate images for a prepared prompt and write them to disk. */
+async function generateAndSave(
+  promptText: string,
+  makeName: (index: number) => string,
+  opts: OutputOptions
+): Promise<void> {
+  console.log(
+    `🎨 Generating ${opts.n} image(s) with gpt-image-2 (size=${opts.size}, quality=${opts.quality})...`
+  );
+  const buffers = await generateImages(promptText, {
+    size: opts.size,
+    quality: opts.quality,
+    n: opts.n,
+    format: opts.format,
+  });
+
+  fs.mkdirSync(opts.out, { recursive: true });
+  buffers.forEach((buf, i) => {
+    const filepath = path.join(opts.out, makeName(i));
+    fs.writeFileSync(filepath, buf);
+    console.log(`✅ Saved ${filepath}`);
+  });
+}
+
+/** Map a locale to its README filename (defaults to README.md). */
+function readmePathForLang(lang: string): string {
+  return SUPPORTED_LANGUAGES.find((l) => l.code === lang)?.readmeFileName ?? "README.md";
+}
+
+// --- CMS-backed paths -------------------------------------------------------
 
 async function runList(lang: string, limit: number): Promise<void> {
   requireEnv("CMS_HOST");
@@ -43,77 +99,93 @@ async function runList(lang: string, limit: number): Promise<void> {
   console.log("\nUse: pnpm run image --id <id>\n");
 }
 
-interface GenerateParams {
-  id: string;
-  lang: string;
-  size: string;
-  quality: ImageQuality;
-  n: number;
-  out: string;
-  format: ImageFormat;
-  arg?: string;
-}
-
-async function runGenerate(params: GenerateParams): Promise<void> {
+async function runFromId(id: string, lang: string, opts: OutputOptions): Promise<void> {
   requireEnv("OPENAI_API_KEY");
   requireEnv("CMS_HOST");
   requireEnv("CMS_API_KEY");
 
-  console.log(`📥 Fetching prompt id=${params.id} from CMS...`);
-  const prompt = await fetchPromptById(params.id, params.lang);
+  console.log(`📥 Fetching prompt id=${id} from CMS...`);
+  const prompt = await fetchPromptById(id, lang);
   if (!prompt) {
-    console.error(`❌ prompt id=${params.id} not found`);
+    console.error(`❌ prompt id=${id} not found`);
     process.exit(1);
   }
-
   if (prompt.needReferenceImages) {
     console.error(
-      `⚠️  id=${params.id} ("${prompt.title}") requires an input image, which v1 does not support. Use --image once editing is added. Skipping.`
+      `⚠️  id=${id} ("${prompt.title}") requires an input image, which v1 does not support. Skipping.`
     );
     process.exit(1);
   }
 
   const rawText =
-    params.lang !== "en" && prompt.translatedContent
-      ? prompt.translatedContent
-      : prompt.content;
-  let promptText = cleanPromptContent(rawText);
+    lang !== "en" && prompt.translatedContent ? prompt.translatedContent : prompt.content;
+  const promptText = applyArgs(cleanPromptContent(rawText), opts.arg);
+  await generateAndSave(
+    promptText,
+    (i) => buildImageFilename(prompt.id, prompt.title, i, opts.format),
+    opts
+  );
+}
 
-  if (hasArguments(promptText)) {
-    if (params.arg) {
-      promptText = substituteArguments(promptText, params.arg);
-      console.log(`🔤 Substituted {argument} placeholders with: "${params.arg}"`);
-    } else {
-      console.warn(
-        `⚠️  Prompt contains unresolved {argument} placeholders. Pass --arg "<text>" to fill them. Continuing as-is.`
-      );
-    }
+// --- README-backed paths (no CMS needed) ------------------------------------
+
+function runReadmeList(lang: string, limit: number): void {
+  const readmePath = readmePathForLang(lang);
+  if (!fs.existsSync(readmePath)) {
+    console.error(`❌ ${readmePath} not found`);
+    process.exit(1);
+  }
+  const prompts = parseReadmePrompts(fs.readFileSync(readmePath, "utf-8"));
+  console.log(`\nPrompts in ${readmePath} (${Math.min(limit, prompts.length)} of ${prompts.length}):\n`);
+  prompts.slice(0, limit).forEach((p) => {
+    console.log(`  No.${String(p.no).padStart(3)}  ${p.title}`);
+  });
+  console.log("\nUse: pnpm run image --no <number>\n");
+}
+
+async function runFromReadme(no: number, lang: string, opts: OutputOptions): Promise<void> {
+  requireEnv("OPENAI_API_KEY");
+
+  const readmePath = readmePathForLang(lang);
+  if (!fs.existsSync(readmePath)) {
+    console.error(`❌ ${readmePath} not found`);
+    process.exit(1);
+  }
+  const prompt = getReadmePromptByNo(fs.readFileSync(readmePath, "utf-8"), no);
+  if (!prompt) {
+    console.error(`❌ No.${no} not found in ${readmePath}`);
+    process.exit(1);
   }
 
-  console.log(
-    `🎨 Generating ${params.n} image(s) with gpt-image-2 (size=${params.size}, quality=${params.quality})...`
+  console.log(`📖 Using ${readmePath} No.${no}: ${prompt.title}`);
+  const promptText = applyArgs(cleanPromptContent(prompt.content), opts.arg);
+  await generateAndSave(
+    promptText,
+    (i) => buildImageFilename(prompt.no, prompt.title, i, opts.format),
+    opts
   );
-  const buffers = await generateImages(promptText, {
-    size: params.size,
-    quality: params.quality,
-    n: params.n,
-    format: params.format,
-  });
+}
 
-  fs.mkdirSync(params.out, { recursive: true });
-  buffers.forEach((buf, i) => {
-    const filename = buildImageFilename(prompt.id, prompt.title, i, params.format);
-    const filepath = path.join(params.out, filename);
-    fs.writeFileSync(filepath, buf);
-    console.log(`✅ Saved ${filepath}`);
-  });
+// --- Free-text path (no CMS, no README) -------------------------------------
+
+async function runFromPrompt(text: string, opts: OutputOptions): Promise<void> {
+  requireEnv("OPENAI_API_KEY");
+  const promptText = applyArgs(text, opts.arg);
+  await generateAndSave(
+    promptText,
+    (i) => `prompt-${slugify(text)}-${i + 1}.${opts.format}`,
+    opts
+  );
 }
 
 async function main(): Promise<void> {
   const { values } = parseArgs({
     options: {
+      prompt: { type: "string" },
       id: { type: "string" },
+      no: { type: "string" },
       list: { type: "boolean", default: false },
+      "readme-list": { type: "boolean", default: false },
       limit: { type: "string", default: "50" },
       lang: { type: "string", default: "en" },
       size: { type: "string", default: "1024x1024" },
@@ -125,30 +197,34 @@ async function main(): Promise<void> {
     },
   });
 
-  if (values.list) {
-    await runList(values.lang as string, parseInt(values.limit as string, 10));
-    return;
-  }
-
-  if (!values.id) {
-    console.error(
-      "Usage:\n" +
-        "  pnpm run image --id <id> [--lang <locale>] [--size <s>] [--quality <q>] [--n <count>] [--out <dir>] [--format <fmt>] [--arg <text>]\n" +
-        "  pnpm run image --list [--limit <n>]"
-    );
-    process.exit(1);
-  }
-
-  await runGenerate({
-    id: values.id as string,
-    lang: values.lang as string,
+  const lang = values.lang as string;
+  const limit = parseInt(values.limit as string, 10);
+  const opts: OutputOptions = {
     size: values.size as string,
     quality: values.quality as ImageQuality,
     n: parseInt(values.n as string, 10),
     out: values.out as string,
     format: values.format as ImageFormat,
     arg: values.arg as string | undefined,
-  });
+  };
+
+  if (values.prompt) return runFromPrompt(values.prompt as string, opts);
+  if (values.no) return runFromReadme(parseInt(values.no as string, 10), lang, opts);
+  if (values["readme-list"]) return runReadmeList(lang, limit);
+  if (values.list) return runList(lang, limit);
+  if (values.id) return runFromId(values.id as string, lang, opts);
+
+  console.error(
+    "Usage:\n" +
+      '  pnpm run image --prompt "<text>"          Generate from free text (no CMS)\n' +
+      "  pnpm run image --no <number>              Generate from README No.<number> (no CMS)\n" +
+      "  pnpm run image --id <id>                  Generate from a CMS prompt (needs CMS_HOST/CMS_API_KEY)\n" +
+      "  pnpm run image --readme-list [--limit n]  List prompts parsed from the README\n" +
+      "  pnpm run image --list [--limit n]         List prompts from the CMS\n" +
+      "\n" +
+      "Options: --lang <locale> --size <s> --quality <low|medium|high|auto> --n <count> --out <dir> --format <png|webp|jpeg> --arg <text>"
+  );
+  process.exit(1);
 }
 
 main().catch((err) => {

--- a/scripts/utils/cms-client.ts
+++ b/scripts/utils/cms-client.ts
@@ -342,6 +342,38 @@ export async function findPromptByGitHubIssue(
 }
 
 /**
+ * Fetch a single prompt by its CMS id.
+ * Returns null when the prompt does not exist (HTTP 404).
+ */
+export async function fetchPromptById(
+  id: number | string,
+  locale: string = "en"
+): Promise<Prompt | null> {
+  const query = { depth: 2, locale };
+  const stringifiedQuery = stringify(query, { addQueryPrefix: true });
+  const url = `${CMS_HOST}/api/prompts/${id}${stringifiedQuery}`;
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `users API-Key ${CMS_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(
+      `CMS API error (${response.status}) fetching prompt ${id}: ${response.statusText}`
+    );
+  }
+
+  const data = (await response.json()) as Prompt;
+  return processPromptImages(data);
+}
+
+/**
  * 创建新 prompt（直接发布，无草稿）
  */
 export async function createPrompt(

--- a/scripts/utils/image-generator.ts
+++ b/scripts/utils/image-generator.ts
@@ -1,0 +1,52 @@
+import OpenAI from "openai";
+
+export type ImageQuality = "low" | "medium" | "high" | "auto";
+export type ImageFormat = "png" | "webp" | "jpeg";
+
+export interface GenerateOptions {
+  size?: string;
+  quality?: ImageQuality;
+  n?: number;
+  format?: ImageFormat;
+}
+
+const MODEL = "gpt-image-2";
+
+/**
+ * Generate images from a text prompt with gpt-image-2.
+ * gpt-image models always return base64, so each image is decoded to a Buffer.
+ */
+export async function generateImages(
+  prompt: string,
+  opts: GenerateOptions = {}
+): Promise<Buffer[]> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is not set");
+  }
+
+  const client = new OpenAI({ apiKey });
+
+  // tsx strips types at runtime, so passing gpt-image-2 params the installed
+  // SDK types may not know about (e.g. output_format) is safe.
+  const result = await client.images.generate({
+    model: MODEL,
+    prompt,
+    size: opts.size ?? "1024x1024",
+    quality: opts.quality ?? "auto",
+    n: opts.n ?? 1,
+    output_format: opts.format ?? "png",
+  } as OpenAI.ImageGenerateParams);
+
+  const data = result.data ?? [];
+  if (data.length === 0) {
+    throw new Error("Image API returned no images");
+  }
+
+  return data.map((img) => {
+    if (!img.b64_json) {
+      throw new Error("Image API response missing b64_json");
+    }
+    return Buffer.from(img.b64_json, "base64");
+  });
+}

--- a/scripts/utils/prompt-preparer.test.ts
+++ b/scripts/utils/prompt-preparer.test.ts
@@ -1,0 +1,46 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  cleanPromptContent,
+  hasArguments,
+  substituteArguments,
+  slugify,
+  buildImageFilename,
+} from "./prompt-preparer.js";
+
+test("cleanPromptContent strips a plain ``` fence and trims", () => {
+  const input = "```\nA red cube on white\n```";
+  assert.equal(cleanPromptContent(input), "A red cube on white");
+});
+
+test("cleanPromptContent strips a ```json language fence", () => {
+  const input = "```json\n{\"a\":1}\n```";
+  assert.equal(cleanPromptContent(input), '{"a":1}');
+});
+
+test("cleanPromptContent returns plain text unchanged (trimmed)", () => {
+  assert.equal(cleanPromptContent("  hello  "), "hello");
+});
+
+test("hasArguments detects {argument tokens", () => {
+  assert.equal(hasArguments("draw {argument name=\"x\"}"), true);
+  assert.equal(hasArguments("draw a cat"), false);
+});
+
+test("substituteArguments replaces every {argument...} token", () => {
+  const out = substituteArguments("A {argument} riding a {argument name=\"y\"}", "dog");
+  assert.equal(out, "A dog riding a dog");
+});
+
+test("slugify lowercases, hyphenates, and truncates", () => {
+  assert.equal(slugify("A Red Cube!! On White"), "a-red-cube-on-white");
+  assert.equal(slugify("x".repeat(60), 10), "xxxxxxxxxx");
+});
+
+test("slugify falls back to 'prompt' for non-latin titles", () => {
+  assert.equal(slugify("猫の宇宙飛行士"), "prompt");
+});
+
+test("buildImageFilename composes id, slug, 1-based index, and format", () => {
+  assert.equal(buildImageFilename(42, "Cat Astronaut", 0, "png"), "42-cat-astronaut-1.png");
+});

--- a/scripts/utils/prompt-preparer.ts
+++ b/scripts/utils/prompt-preparer.ts
@@ -1,0 +1,42 @@
+/**
+ * Remove code-block markers (``` or ```json etc.) from prompt content.
+ * Mirrors the logic in markdown-generator.ts; kept separate so the README
+ * pipeline stays untouched in v1.
+ */
+export function cleanPromptContent(content: string): string {
+  if (!content) return content;
+  let cleaned = content;
+  cleaned = cleaned.replace(/^```[\w-]*\s*\n?/im, "");
+  cleaned = cleaned.replace(/\n?```\s*$/im, "");
+  cleaned = cleaned.replace(/\n```[\w-]*\s*\n/g, "\n");
+  return cleaned.trim();
+}
+
+/** True when the prompt still contains Raycast-style {argument...} placeholders. */
+export function hasArguments(content: string): boolean {
+  return content.includes("{argument");
+}
+
+/** Replace every {argument...} token with the provided value. */
+export function substituteArguments(content: string, value: string): string {
+  return content.replace(/\{argument[^}]*\}/g, value);
+}
+
+/** Filesystem-safe slug from a title. Falls back to "prompt" when empty. */
+export function slugify(title: string, maxLen = 40): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug.slice(0, maxLen).replace(/-+$/g, "") || "prompt";
+}
+
+/** Build an output filename like `42-cat-astronaut-1.png` (index is 0-based). */
+export function buildImageFilename(
+  id: number,
+  title: string,
+  index: number,
+  format: string
+): string {
+  return `${id}-${slugify(title)}-${index + 1}.${format}`;
+}

--- a/scripts/utils/readme-parser.test.ts
+++ b/scripts/utils/readme-parser.test.ts
@@ -1,0 +1,58 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseReadmePrompts, getReadmePromptByNo } from "./readme-parser.js";
+
+const SAMPLE = [
+  "## Featured",
+  "",
+  "### No. 1: First Prompt",
+  "",
+  "![Language-EN](x)",
+  "",
+  "#### 📖 Description",
+  "",
+  "Desc one.",
+  "",
+  "#### 📝 Prompt",
+  "",
+  "```",
+  'A red cube {argument name="x"}',
+  "```",
+  "",
+  "#### 📌 Details",
+  "",
+  "---",
+  "",
+  "### No. 2: Second Prompt",
+  "",
+  "#### 📝 Prompt",
+  "",
+  "```",
+  "A blue sphere",
+  "on white",
+  "```",
+  "",
+  "---",
+].join("\n");
+
+test("parseReadmePrompts returns every No. section with title and fenced content", () => {
+  const prompts = parseReadmePrompts(SAMPLE);
+  assert.equal(prompts.length, 2);
+  assert.deepEqual(prompts[0], {
+    no: 1,
+    title: "First Prompt",
+    content: 'A red cube {argument name="x"}',
+  });
+  assert.equal(prompts[1].no, 2);
+  assert.equal(prompts[1].title, "Second Prompt");
+  assert.equal(prompts[1].content, "A blue sphere\non white");
+});
+
+test("getReadmePromptByNo returns the matching prompt", () => {
+  const p = getReadmePromptByNo(SAMPLE, 2);
+  assert.equal(p?.content, "A blue sphere\non white");
+});
+
+test("getReadmePromptByNo returns null for a missing number", () => {
+  assert.equal(getReadmePromptByNo(SAMPLE, 99), null);
+});

--- a/scripts/utils/readme-parser.ts
+++ b/scripts/utils/readme-parser.ts
@@ -1,0 +1,40 @@
+export interface ReadmePrompt {
+  no: number;
+  title: string;
+  content: string;
+}
+
+// Matches the per-prompt heading emitted by markdown-generator: "### No. 5: Title".
+const HEADING_RE = /^### No\. (\d+): (.+)$/gm;
+// Matches the first fenced code block in a section (the prompt body).
+const FENCE_RE = /```[\w-]*\n([\s\S]*?)\n```/;
+
+/**
+ * Parse all prompts out of a generated README. For each "### No. N: Title"
+ * heading, the prompt body is the first fenced code block in that section.
+ */
+export function parseReadmePrompts(markdown: string): ReadmePrompt[] {
+  const results: ReadmePrompt[] = [];
+  const headings = [...markdown.matchAll(HEADING_RE)];
+
+  for (let i = 0; i < headings.length; i++) {
+    const m = headings[i];
+    const no = parseInt(m[1], 10);
+    const title = m[2].trim();
+    const start = (m.index ?? 0) + m[0].length;
+    const end = i + 1 < headings.length ? headings[i + 1].index ?? markdown.length : markdown.length;
+    const section = markdown.slice(start, end);
+
+    const fence = section.match(FENCE_RE);
+    if (fence) {
+      results.push({ no, title, content: fence[1] });
+    }
+  }
+
+  return results;
+}
+
+/** Return the prompt whose "No." equals `no`, or null when absent. */
+export function getReadmePromptByNo(markdown: string, no: number): ReadmePrompt | null {
+  return parseReadmePrompts(markdown).find((p) => p.no === no) ?? null;
+}


### PR DESCRIPTION
## Summary

Adds a CLI (`pnpm run image`) that generates images with OpenAI `gpt-image-2`
from prompts sourced three ways:

- `--prompt "<text>"` — free text (no CMS)
- `--no <n>` — a prompt parsed from the local README by its "No." heading (no CMS)
- `--id <id>` — a prompt fetched live from the CMS (needs `CMS_HOST` / `CMS_API_KEY`)

Plus `--readme-list` / `--list` for discovery. Images are written to `output/`
(git-ignored). Prompts flagged `needReferenceImages` are skipped with a warning
(v1 is text-to-image only).

## Changes

- `scripts/generate-image.ts` — CLI entry point + arg routing
- `scripts/utils/image-generator.ts` — thin `openai.images.generate` wrapper (base64 → Buffer)
- `scripts/utils/prompt-preparer.ts` (+ tests) — pure helpers: clean content, `{argument}` detect/substitute, slug/filename
- `scripts/utils/readme-parser.ts` (+ tests) — parse prompts from a generated README
- `scripts/utils/cms-client.ts` — add `fetchPromptById`
- `package.json` — `image` + `test` scripts, `openai` dependency
- `.gitignore` — ignore `output/`
- docs — `LOCAL_DEVELOPMENT.md` usage + design spec/plan under `docs/superpowers/`

## Testing

- `pnpm test` — 11/11 unit tests pass
- Verified end-to-end against `gpt-image-2`: `--prompt` and `--no 5` each produced a valid 1024×1024 PNG.

## Notes

- Model is fixed to `gpt-image-2`.
- Design spec: `docs/superpowers/specs/2026-07-16-catalog-image-generation-cli-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195oxt5sg7RGriWmxL1Hw3L
