### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -5682,7 +5682,7 @@ Licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-gpt-image-2&Date)
 
 ---
 

--- a/README_de-DE.md
+++ b/README_de-DE.md
@@ -5742,7 +5742,7 @@ Lizenziert unter [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
 ## ⭐ Star-Verlauf
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-gpt-image-2&Date)
 
 ---
 

--- a/README_es-419.md
+++ b/README_es-419.md
@@ -5748,7 +5748,7 @@ Licenciado bajo [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
 ## ⭐ Historial de estrellas
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-gpt-image-2&Date)
 
 ---
 

--- a/README_es-ES.md
+++ b/README_es-ES.md
@@ -5742,7 +5742,7 @@ Licenciado bajo [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
 ## ⭐ Historial de estrellas
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-gpt-image-2&Date)
 
 ---
 

--- a/README_fr-FR.md
+++ b/README_fr-FR.md
@@ -5742,7 +5742,7 @@ Sous licence [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
 ## ⭐ Historique des étoiles
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-gpt-image-2&Date)
 
 ---
 

--- a/README_hi-IN.md
+++ b/README_hi-IN.md
@@ -5748,7 +5748,7 @@ The gallery features:
 
 ## ⭐ स्टार इतिहास
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-gpt-image-2&Date)
 
 ---
 

--- a/README_it-IT.md
+++ b/README_it-IT.md
@@ -5742,7 +5742,7 @@ Concesso in licenza sotto [CC BY 4.0](https://creativecommons.org/licenses/by/4.
 
 ## ⭐ Cronologia stelle
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-gpt-image-2&Date)
 
 ---
 

--- a/README_ja-JP.md
+++ b/README_ja-JP.md
@@ -5746,7 +5746,7 @@ The gallery features:
 
 ## ⭐ スター履歴
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-gpt-image-2&Date)
 
 ---
 

--- a/README_ko-KR.md
+++ b/README_ko-KR.md
@@ -5728,7 +5728,7 @@ The gallery features:
 
 ## ⭐ 스타 히스토리
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-gpt-image-2&Date)
 
 ---
 

--- a/README_pt-BR.md
+++ b/README_pt-BR.md
@@ -5742,7 +5742,7 @@ Licenciado sob [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
 ## ⭐ Histórico de estrelas
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-gpt-image-2&Date)
 
 ---
 

--- a/README_pt-PT.md
+++ b/README_pt-PT.md
@@ -5742,7 +5742,7 @@ Licenciado sob [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
 ## ⭐ Histórico de estrelas
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-gpt-image-2&Date)
 
 ---
 

--- a/README_th-TH.md
+++ b/README_th-TH.md
@@ -5748,7 +5748,7 @@ The gallery features:
 
 ## ⭐ ประวัติดาว
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-gpt-image-2&Date)
 
 ---
 

--- a/README_tr-TR.md
+++ b/README_tr-TR.md
@@ -5742,7 +5742,7 @@ Detaylı yönergeler için [CONTRIBUTING.md](docs/CONTRIBUTING.md) dosyasına ba
 
 ## ⭐ Yıldız Geçmişi
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-gpt-image-2&Date)
 
 ---
 

--- a/README_vi-VN.md
+++ b/README_vi-VN.md
@@ -5742,7 +5742,7 @@ Xem [CONTRIBUTING.md](docs/CONTRIBUTING.md) để biết hướng dẫn chi ti�
 
 ## ⭐ Lịch sử sao
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-gpt-image-2&Date)
 
 ---
 

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -5748,7 +5748,7 @@ The gallery features:
 
 ## ⭐ Star 歷史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-gpt-image-2&Date)
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -5748,7 +5748,7 @@ The gallery features:
 
 ## ⭐ Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-gpt-image-2&Date)
 
 ---
 

--- a/scripts/utils/markdown-generator.ts
+++ b/scripts/utils/markdown-generator.ts
@@ -450,7 +450,7 @@ ${t('licensedUnder', locale)}
 
 ## ⭐ ${t('starHistory', locale)}
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-gpt-image-2&Date)
 
 ---
 


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This change points the chart to star-history.dera.page, which uses an alternative data source requiring no API token, so the chart renders correctly again.